### PR TITLE
fix: daily data collection workflow failing - missing output directory

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,26 @@
+# Build and Deployment Issues
+
+## GitHub Actions Daily Data Collection Failure
+
+### Issue
+The daily data collection GitHub Actions workflow was failing when executing `./target/release/top200-rs export-combined`.
+
+### Root Cause
+The `export-combined` command tries to create CSV files in the `output/` directory without ensuring the directory exists first. The functions `export_market_caps()` and `export_top_100_active()` in `src/marketcaps.rs` would call `std::fs::File::create()` on paths like:
+- `output/combined_marketcaps_{timestamp}.csv`
+- `output/top_100_active_{timestamp}.csv`
+
+When the `output/` directory doesn't exist (as in a fresh GitHub Actions environment), these calls would fail.
+
+### Solution
+Added `std::fs::create_dir_all("output")?;` before file creation in both export functions to ensure the output directory exists.
+
+### Files Modified
+- `src/marketcaps.rs`: Lines 210 and 260 - Added directory creation before CSV file exports
+
+### Testing
+The fix ensures the application can run in any environment where the output directory may not exist, including:
+- Fresh GitHub Actions runners
+- Clean development environments
+- Docker containers
+- New clones of the repository

--- a/src/marketcaps.rs
+++ b/src/marketcaps.rs
@@ -206,6 +206,9 @@ pub async fn export_market_caps(pool: &SqlitePool) -> Result<()> {
     // Sort by EUR market cap
     results.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
+    // Ensure output directory exists
+    std::fs::create_dir_all("output")?;
+
     // Export to CSV
     let timestamp = Local::now().format("%Y%m%d_%H%M%S");
     let filename = format!("output/combined_marketcaps_{}.csv", timestamp);
@@ -252,6 +255,9 @@ pub async fn export_top_100_active(pool: &SqlitePool) -> Result<()> {
         .filter(|(_, record)| record[8] == "true") // Active column
         .take(100)
         .collect();
+
+    // Ensure output directory exists
+    std::fs::create_dir_all("output")?;
 
     // Export to CSV
     let timestamp = Local::now().format("%Y%m%d_%H%M%S");


### PR DESCRIPTION
Fixes the daily data collection GitHub Actions workflow that was failing due to missing output directory creation.

## Changes
- Added `std::fs::create_dir_all("output")?;` before CSV file creation in marketcaps.rs
- Added documentation explaining the issue and solution

## Testing
The fix ensures the application works in fresh environments where the output directory doesn't exist.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)